### PR TITLE
Ensure that the chart is compatible with the current appstore API

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ helm delete DEPLOYMENT
 
 ```
 helm package jupyter
-mv jupyter-0.1.0.tgz docs/
+mv jupyter-0.2.0.tgz docs/
 helm repo index docs --url https://UNINETT.github.com/helm-charts
 
 ```

--- a/docs/index.yaml
+++ b/docs/index.yaml
@@ -7,6 +7,6 @@ entries:
     digest: 3758ec26823ae82eaaa3c5543198fa17341767fc8d9f25683ed2644bf14caf54
     name: jupyter
     urls:
-    - https://uninett.github.io/helm-charts/jupyter-0.1.0.tgz
-    version: 0.1.0
+    - https://uninett.github.io/helm-charts/jupyter-0.2.0.tgz
+    version: 0.2.0
 generated: 2017-06-19T14:06:51.385711137+02:00

--- a/jupyter/Chart.yaml
+++ b/jupyter/Chart.yaml
@@ -1,5 +1,4 @@
 apiVersion: v1
 description: Jupyter notebook with Dataporten integration
 name: jupyter
-version: 0.1.0
-dataporten-path: /callback
+version: 0.2.0

--- a/jupyter/resources.yaml
+++ b/jupyter/resources.yaml
@@ -1,0 +1,7 @@
+dataporten:
+  Options:
+    ScopesRequested:
+      - profile
+      - openid
+    RedirectURI:
+      - /oauth2/callback

--- a/jupyter/templates/_helpers.tpl
+++ b/jupyter/templates/_helpers.tpl
@@ -21,11 +21,11 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
     "target": "http://localhost:8888"
   },
   "engine": {
-    "client_id": "{{ .Values.secrets.dataporten.client_id }}",
-    "client_secret": "{{ .Values.secrets.dataporten.client_secret }}",
+    "client_id": "{{ .Values.appstore_generated_data.dataporten.id }}",
+    "client_secret": "{{ .Values.appstore_generated_data.dataporten.client_secret }}",
     "issuer_url": "https://auth.dataporten.no",
     "redirect_url": "https://{{ .Values.ingress.host }}/oauth2/callback",
-    "scopes": "{{ .Values.secrets.dataporten.scopes }}",
+    "scopes": "{{ .Values.appstore_generated_data.dataporten.scopes }}",
     "signkey": "{{ randAlphaNum 60 }}",
     "token_type": "",
     "jwt_token_issuer": "",

--- a/jupyter/templates/secret.yaml
+++ b/jupyter/templates/secret.yaml
@@ -6,6 +6,6 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
 type: Opaque
 data:
-  dataporten_client_id: {{ .Values.secrets.dataporten.client_id | b64enc }}
-  dataporten_client_secret: {{ .Values.secrets.dataporten.client_secret | b64enc }}
+  dataporten_client_id: {{ .Values.appstore_generated_data.dataporten.id | b64enc }}
+  dataporten_client_secret: {{ .Values.appstore_generated_data.dataporten.client_secret | b64enc }}
   goidc.json: {{ include "oidcconfig" . | b64enc }} 

--- a/jupyter/values.yaml
+++ b/jupyter/values.yaml
@@ -29,8 +29,7 @@ resources:
   requests:
     cpu: 100m
     memory: 128Mi
-secrets:
+appstore_generated_data:
   dataporten:
-    client_id: foo
-    client_secret: blah
-    scopes: userid,groups
+    id: ""
+    client_secret: ""


### PR DESCRIPTION
The chart would previously not work with the appstore, as some of value keys were not the same as what was expected by the appstore API and the dataporten plugin.